### PR TITLE
Fix compiling on BYOND 510

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -194,6 +194,7 @@
  * Text modification
  */
 // See bygex.dm
+#if DM_VERSION < 510
 #ifndef USE_BYGEX
 /proc/replacetext(text, find, replacement)
 	return list2text(text2list(text, find), replacement)
@@ -201,6 +202,7 @@
 /proc/replacetextEx(text, find, replacement)
 	return list2text(text2listEx(text, find), replacement)
 #endif
+#endif\
 
 //Adds 'u' number of zeros ahead of the text 't'
 /proc/add_zero(t, u)

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -248,7 +248,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	reqform.info += "RANK: [orderedbyRank]<br>"
 	reqform.info += "REASON: [comment]<br>"
 	reqform.info += "SUPPLY CRATE TYPE: [object.name]<br>"
-	reqform.info += "ACCESS RESTRICTION: [replacetext(get_access_desc(object.access))]<br>"
+	reqform.info += "ACCESS RESTRICTION: [get_access_desc(object.access)]<br>"
 	reqform.info += "CONTENTS:<br>"
 	reqform.info += object.manifest
 	reqform.info += "<hr>"


### PR DESCRIPTION
BYOND 510 adds replacetext as a builtin, so it's only compiled if you're below 510
