### PR TITLE
Fix blast doors leaking air

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -74,12 +74,12 @@
 	flick("closing", src)
 	icon_state = "closed"
 	src.set_opacity(1)
-	air_update_turf(1)
 	update_freelook_sight()
 	sleep(5)
 	crush()
 	density = 1
 	sleep(5)
+	air_update_turf(1)
 
 	operating = 0
 


### PR DESCRIPTION
Seems blast doors did not close in the right order, so they kept leaking air
