### PR TITLE
Fix turfs near tunnels and hidden rooms in z5 having no icon

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -19,3 +19,4 @@ var/global/list/turfs = list()						//all the turfs
 var/global/list/areas = list()						//all the areas
 
 var/global/list/mining_turfs = list()				//all mining minerals walls, used by some lighting code
+var/global/list/tunnel_walls = list()				//all simulated walls affected by tunnel-making in the asteroid

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -146,6 +146,14 @@ Calculate the longest number of ticks the MC can wait between each cycle without
 		if(T.lighting_test_overlays())
 			T.lighting_fix_overlays()
 
+	for(var/turf/simulated/wall/W in tunnel_walls)
+		set background = TRUE
+		if(!W)
+			continue
+		if(W.smooth)
+			smooth_icon(W)
+			W.icon_state = ""
+
 
 /datum/controller/game_controller/proc/Recover()
 	var/msg = "## DEBUG: [time2text(world.timeofday)] MC restarted. Reports:\n"

--- a/code/game/asteroid.dm
+++ b/code/game/asteroid.dm
@@ -32,6 +32,10 @@ proc/spawn_room(var/atom/start_loc, var/x_size, var/y_size, var/list/walltypes, 
 
 			A.contents += T
 
+	for(var/turf/simulated/wall/W in room_turfs["walls"])
+		if(W.smooth)
+			smooth_icon(W)
+			W.icon_state = ""
 	return room_turfs
 
 //////////////
@@ -183,10 +187,6 @@ proc/make_mining_asteroid_secret()
 
 	if(room)//time to fill it with stuff
 		var/list/emptyturfs = room["floors"]
-		for(var/turf/simulated/floor/A in emptyturfs) //remove pls doesn't fix problem
-			if(istype(A))
-				spawn(2)
-					A.fullUpdateMineralOverlays()
 		T = pick(emptyturfs)
 		if(T)
 			new /obj/effect/glowshroom/single(T) //Just to make it a little more visible

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -410,6 +410,9 @@
 		if(istype(S, /turf/space) || istype(S.loc, /area/space/mine/explored))
 			sanity = 0
 			break
+		var/turf/simulated/wall/W = S
+		if(istype(W))
+			tunnel_walls += W
 	if(!sanity)
 		return
 


### PR DESCRIPTION
This was caused by icon smoothing during creation, resmoothing fixes it
